### PR TITLE
[CBRD-23619] Gcc and g++ should be required version 8 to build Regex …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,19 @@
 dist: trusty
 language: cpp
-
-compiler:
-  - gcc
-
+env: CC=gcc-8 CXX=g++-8
 os:
 - linux
-
 addons:
   apt:
     sources:
       - kalakris-cmake
+      - ubuntu-toolchain-r-test
     packages:
+      - gcc-8
+      - g++-8
       - cmake
       - systemtap-sdt-dev
       - libelf-dev
-
 script:
   - cmake -E make_directory build
   - cmake -E chdir build cmake ..


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23619

Travis CI needs to upgrade gcc and g++ to 8 version